### PR TITLE
docs: Align disabled default guidance (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Aligned `disabled` default guidance across engine docstring, `README.md`, and `settings-snippet.yml` with clear distinction between upstream (opt-in) and personal deployment use cases.
 - Switched networking from `urllib.request` to shared `searx.network.get` (httpx-style).
 - Hardened payload validation (top-level list requirement, strict type checking for categories and scripts).
 - Improved slug normalization using a new `_slugify` helper (NFKD normalization, lowercase, special character removal).

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ Add this block under `engines:` in your SearXNG settings file (typically `/etc/s
     engine: community_scripts_proxmoxve
     shortcut: pve
     categories: [it]
-    disabled: false
+    disabled: false   # the engine ships disabled by default; set to false to enable on your instance
 ```
+
+> **Note:** The engine defaults to `disabled: true` (opt-in) for upstream safety. The snippet above uses `disabled: false` because you are installing it on your own instance and want it active immediately. See `settings-snippet.yml` for an upstream-ready example.
 
 ### 3. Restart SearXNG
 

--- a/searx/engines/community_scripts_proxmoxve.py
+++ b/searx/engines/community_scripts_proxmoxve.py
@@ -13,13 +13,17 @@ the user's query never leaves the SearXNG instance.
 Configuration
 =============
 
+The engine defaults to ``disabled = True`` so it must be explicitly enabled.
+For a personal instance set ``disabled: false``; for an upstream contribution
+keep the default so that users opt in.
+
 .. code:: yaml
 
    - name: proxmox ve community scripts
      engine: community_scripts_proxmoxve
      shortcut: pve
      categories: [it]
-     disabled: false
+     disabled: true       # set to false on your own instance
 
 Implementations
 ===============

--- a/settings-snippet.yml
+++ b/settings-snippet.yml
@@ -1,9 +1,14 @@
 # Add this block to /etc/searxng/settings.yml under the `engines:` list.
-# For upstream: insert alphabetically among other engines.
-# For personal use: set `disabled: false` to enable by default.
+#
+# Upstream contribution:
+#   Insert alphabetically among other engines and keep `disabled: true`
+#   so users opt in explicitly.
+#
+# Personal instance:
+#   Set `disabled: false` to enable the engine immediately.
 
   - name: proxmox ve community scripts
     engine: community_scripts_proxmoxve
     shortcut: pve
     categories: [it]
-    disabled: true
+    disabled: true       # set to false on your own instance


### PR DESCRIPTION
## **User description**
## Summary

- Aligned `disabled` default guidance across engine docstring, `README.md`, and `settings-snippet.yml`
- Engine docstring now shows `disabled: true` (matching the Python module default) with an inline comment for personal override
- README install snippet keeps `disabled: false` (personal use) with a note explaining the upstream default
- `settings-snippet.yml` comments restructured to clearly separate upstream vs personal instance guidance
- Updated CHANGELOG.md

## Test Plan
- [ ] Verify all three files use consistent terminology for upstream vs personal deployment
- [ ] Confirm engine module `disabled = True` default is unchanged

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Clarify engine disabled default and opt-in guidance across docs

### What Changed
- The engine docstring now states the engine defaults to disabled (true) and notes how to enable it on a personal instance
- README keeps the install snippet with disabled: false for local installs and adds an explicit note that the upstream default is disabled (opt-in)
- settings-snippet.yml adds separate, clear guidance for upstream contributions (keep disabled: true) and personal instances (set disabled: false); in-file comments explain the intended use

### Impact
`✅ Clearer install guidance`
`✅ Fewer upstream-enabled mistakes`
`✅ Shorter setup for personal instances`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified the default disabled state for the Proxmox VE engine across all documentation and configuration examples.
  * Added explicit guidance distinguishing upstream deployments (disabled by default) from personal instance configurations (can be enabled as needed).
  * Improved setup instructions and inline comments to help users understand and configure the engine appropriately for their deployment type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->