### PR TITLE
fix: retarget engine against PocketBase API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SearXNG Engine: Proxmox VE Community Scripts
 
-A [SearXNG](https://github.com/searxng/searxng) engine that searches the [Proxmox VE Community Scripts](https://community-scripts.github.io/ProxmoxVE/) catalogue: ~480 install scripts for LXC containers, VMs, and add-ons.
+A [SearXNG](https://github.com/searxng/searxng) engine that searches the [Proxmox VE Community Scripts](https://community-scripts.org/) catalogue: ~550 install scripts for LXC containers, VMs, and add-ons.
 
 Instead of navigating to the community scripts site, search the catalogue directly from SearXNG — intermixed with broader results or exclusively via the `!pve` bang. Anything that connects to your SearXNG instance (like [Seek: SearXNG for Alfred](https://github.com/ggfevans/searxng-seek-alfred)) gets access to the catalogue automatically.
 

--- a/searx/engines/community_scripts_proxmoxve.py
+++ b/searx/engines/community_scripts_proxmoxve.py
@@ -4,9 +4,9 @@
 
 This engine searches the community-maintained catalogue of installation scripts
 for Proxmox VE containers, virtual machines, and add-ons hosted at
-`community-scripts.github.io/ProxmoxVE <https://community-scripts.github.io/ProxmoxVE/>`_.
+`community-scripts.org <https://community-scripts.org/>`_.
 
-The catalogue (~480 scripts) is fetched once from the static JSON API and cached
+The catalogue (~550 scripts) is fetched once from the PocketBase API and cached
 locally for 12 hours.  Searches run entirely offline against the cached data —
 the user's query never leaves the SearXNG instance.
 
@@ -39,6 +39,7 @@ import re
 import secrets
 import typing as t
 import unicodedata
+from urllib.parse import urlencode
 import zlib
 
 from httpx import HTTPError, TimeoutException
@@ -58,15 +59,19 @@ paging = False
 time_range_support = False
 
 about = {
-    "website": "https://community-scripts.github.io/ProxmoxVE/",
+    "website": "https://community-scripts.org/",
     "wikidata_id": None,
-    "official_api_documentation": None,
-    "use_official_api": False,
+    "official_api_documentation": "https://community-scripts.org/docs/api/readme",
+    "use_official_api": True,
     "require_api_key": False,
     "results": "JSON",
 }
 
-_SCRIPT_URL = "https://community-scripts.github.io/ProxmoxVE/scripts?id={slug}"
+_API_BASE = "https://db.community-scripts.org/api/collections/script_scripts/records"
+_API_PER_PAGE = 500
+_MAX_PAGES = 10  # safety cap: 10 x 500 = 5000 scripts
+
+_SCRIPT_URL = "https://community-scripts.org/scripts/{slug}"
 _CACHE_TTL = 43200  # 12 hours in seconds
 _MAX_RESULTS = 20
 _MAX_CACHE_VALUE_LEN = 10240  # 10 KB
@@ -89,53 +94,57 @@ def _slugify(value: str, max_len: int = 64) -> str:
 
 
 def _fetch_scripts() -> list[dict[str, t.Any]]:
-    """Fetch all scripts from the community-scripts API and return a flat, deduplicated list."""
-    try:
-        resp = get("https://community-scripts.github.io/ProxmoxVE/api/categories", timeout=30)
-        if resp.status_code != 200:
-            _logger.warning("Unexpected community scripts API status: %s", resp.status_code)
-            return []
-        data = resp.json()
-    except (ValueError, HTTPError, TimeoutException) as e:
-        _logger.warning("Failed to fetch community scripts: %s", e)
-        return []
-
-    if not isinstance(data, list):
-        _logger.warning("Unexpected categories payload type: %s", type(data).__name__)
-        return []
-
+    """Fetch all scripts from the PocketBase API and return a flat, deduplicated list."""
     seen: set[str] = set()
     scripts: list[dict[str, t.Any]] = []
-    for category in data:
-        if not isinstance(category, dict):
-            _logger.warning("Skipping malformed category")
-            continue
-        category_scripts = category.get("scripts", [])
-        if not isinstance(category_scripts, list):
-            _logger.warning("Skipping malformed scripts list in category")
-            continue
-        for script in category_scripts:
-            if not isinstance(script, dict):
-                _logger.warning("Skipping malformed script")
+
+    for page_num in range(1, _MAX_PAGES + 1):
+        params = urlencode({
+            "perPage": _API_PER_PAGE,
+            "page": page_num,
+            "fields": "name,slug,description",
+            "filter": "(is_deleted=false&&is_disabled=false)",
+        })
+        url = f"{_API_BASE}?{params}"
+
+        try:
+            resp = get(url, timeout=30)
+            if resp.status_code != 200:
+                _logger.warning("Unexpected PocketBase API status: %s", resp.status_code)
+                return []
+            data = resp.json()
+        except (ValueError, HTTPError, TimeoutException) as e:
+            _logger.warning("Failed to fetch community scripts: %s", e)
+            return []
+
+        if not isinstance(data, dict):
+            _logger.warning("Unexpected payload type: %s", type(data).__name__)
+            return []
+
+        items = data.get("items")
+        if not isinstance(items, list):
+            _logger.warning("Unexpected items type: %s", type(items).__name__)
+            return []
+
+        for item in items:
+            if not isinstance(item, dict):
+                _logger.warning("Skipping malformed item")
                 continue
-            name = script.get("name")
-            slug = script.get("slug")
+            name = item.get("name")
+            slug = item.get("slug")
             if not isinstance(name, str) or not isinstance(slug, str):
                 _logger.warning(
-                    "Skipping script with invalid name/slug: name=%r slug=%r",
+                    "Skipping item with invalid name/slug: name=%r slug=%r",
                     name,
                     slug,
                 )
                 continue
 
             slug = _slugify(slug)
-            if not name or not slug:
+            if not name.strip() or not slug:
                 continue
 
-            if script.get("disable") is True:
-                continue
-
-            # Handle collisions only for enabled scripts
+            # Handle collisions
             original_slug = slug
             counter = 1
             while slug in seen:
@@ -144,13 +153,17 @@ def _fetch_scripts() -> list[dict[str, t.Any]]:
 
             seen.add(slug)
 
-            description = script.get("description")
-            # Truncate description to 500 characters
+            description = item.get("description")
             description = description[:500] if isinstance(description, str) else ""
 
             scripts.append(
                 {"name": name.strip(), "slug": slug, "description": description}
             )
+
+        total_pages = data.get("totalPages", 1)
+        if page_num >= total_pages:
+            break
+
     return scripts
 
 

--- a/tests/test_community_scripts_proxmoxve.py
+++ b/tests/test_community_scripts_proxmoxve.py
@@ -11,6 +11,22 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 ENGINE_PATH = REPO_ROOT / "searx/engines/community_scripts_proxmoxve.py"
 
 
+def _pocketbase_response(
+    items: list,
+    page: int = 1,
+    total_pages: int = 1,
+    total_items: Optional[int] = None,
+) -> dict:
+    """Wrap items in a PocketBase-style paginated envelope."""
+    return {
+        "page": page,
+        "perPage": 500,
+        "totalItems": total_items if total_items is not None else len(items),
+        "totalPages": total_pages,
+        "items": items,
+    }
+
+
 class DummyLogger:
     def __init__(self) -> None:
         self.messages: list[tuple[str, str]] = []
@@ -86,7 +102,7 @@ def load_engine_module() -> tuple[types.ModuleType, DummyLogger]:
     result_types_module.EngineResults = DummyEngineResults
 
     network_module = types.ModuleType("searx.network")
-    network_module.get = lambda url, timeout: FakeHTTPResponse([])
+    network_module.get = lambda url, timeout: FakeHTTPResponse(_pocketbase_response([]))
 
     # Add dummy httpx module
     class DummyHTTPError(Exception):
@@ -142,22 +158,27 @@ class CommunityScriptsTestBase(unittest.TestCase):
             return_value=FakeHTTPResponse(payload, status_code=status_code),
         )
 
+    def _patch_network_get_pages(self, pages: list[object]) -> mock._patch:
+        """Return different responses for successive get() calls (pagination)."""
+        responses = [FakeHTTPResponse(p) for p in pages]
+        return mock.patch.object(self.module, "get", side_effect=responses)
+
 
 class CommunityScriptsNetworkTests(CommunityScriptsTestBase):
 
     def test_fetch_scripts_success(self) -> None:
-        payload = [{"scripts": [{"name": "Test Script", "slug": "test-script"}]}]
+        payload = _pocketbase_response([{"name": "Test Script", "slug": "test-script"}])
         with self._patch_network_get(payload):
             scripts = self.module._fetch_scripts()
         self.assertEqual(len(scripts), 1)
         self.assertEqual(scripts[0]["name"], "Test Script")
 
     def test_fetch_scripts_http_error(self) -> None:
-        with self._patch_network_get([], status_code=500):
+        with self._patch_network_get(_pocketbase_response([]), status_code=500):
             scripts = self.module._fetch_scripts()
         self.assertEqual(scripts, [])
         self.assertTrue(
-            any("Unexpected community scripts API status" in msg for _, msg in self.logger.messages)
+            any("Unexpected PocketBase API status" in msg for _, msg in self.logger.messages)
         )
 
     def test_fetch_scripts_exception(self) -> None:
@@ -168,26 +189,62 @@ class CommunityScriptsNetworkTests(CommunityScriptsTestBase):
             any("Failed to fetch community scripts" in msg for _, msg in self.logger.messages)
         )
 
+    def test_fetch_scripts_pagination(self) -> None:
+        page1 = _pocketbase_response(
+            [{"name": "Script A", "slug": "script-a"}],
+            page=1, total_pages=2, total_items=2,
+        )
+        page2 = _pocketbase_response(
+            [{"name": "Script B", "slug": "script-b"}],
+            page=2, total_pages=2, total_items=2,
+        )
+        with self._patch_network_get_pages([page1, page2]):
+            scripts = self.module._fetch_scripts()
+        self.assertEqual(len(scripts), 2)
+        self.assertEqual(scripts[0]["name"], "Script A")
+        self.assertEqual(scripts[1]["name"], "Script B")
+
+    def test_fetch_scripts_pagination_failure_on_page_2(self) -> None:
+        page1 = _pocketbase_response(
+            [{"name": "Script A", "slug": "script-a"}],
+            page=1, total_pages=2, total_items=2,
+        )
+        with mock.patch.object(
+            self.module, "get",
+            side_effect=[
+                FakeHTTPResponse(page1),
+                self.module.HTTPError("Page 2 failed"),
+            ],
+        ):
+            scripts = self.module._fetch_scripts()
+        self.assertEqual(scripts, [])
+
+    def test_fetch_scripts_empty_items(self) -> None:
+        payload = _pocketbase_response([])
+        with self._patch_network_get(payload):
+            scripts = self.module._fetch_scripts()
+        self.assertEqual(scripts, [])
+
 
 class CommunityScriptsSchemaHardeningTests(CommunityScriptsTestBase):
 
-    def test_fetch_scripts_rejects_non_list_payload(self) -> None:
-        with self._patch_network_get({"scripts": []}):
+    def test_fetch_scripts_rejects_non_dict_payload(self) -> None:
+        with self._patch_network_get([]):
             scripts = self.module._fetch_scripts()
 
         self.assertEqual(scripts, [])
         self.assertTrue(
             any(
-                "Unexpected categories payload type" in message
+                "Unexpected payload type" in message
                 for _level, message in self.logger.messages
             )
         )
 
-    def test_fetch_scripts_skips_malformed_category_entries(self) -> None:
-        payload = [
+    def test_fetch_scripts_skips_malformed_items(self) -> None:
+        payload = _pocketbase_response([
             None,
-            {"scripts": [{"name": "Valid Script", "slug": "valid-script"}]},
-        ]
+            {"name": "Valid Script", "slug": "valid-script"},
+        ])
         with self._patch_network_get(payload):
             scripts = self.module._fetch_scripts()
 
@@ -202,12 +259,12 @@ class CommunityScriptsSchemaHardeningTests(CommunityScriptsTestBase):
             ],
         )
         warning_messages = [message for _level, message in self.logger.messages]
-        self.assertTrue(any("Skipping malformed category" in msg for msg in warning_messages))
+        self.assertTrue(any("Skipping malformed item" in msg for msg in warning_messages))
 
-    def test_fetch_scripts_skips_malformed_script_entries_within_category(self) -> None:
-        payload = [
-            {"scripts": [1, "broken", {"name": "Valid Script", "slug": "valid-script"}]},
-        ]
+    def test_fetch_scripts_skips_malformed_items_in_response(self) -> None:
+        payload = _pocketbase_response([
+            1, "broken", {"name": "Valid Script", "slug": "valid-script"},
+        ])
         with self._patch_network_get(payload):
             scripts = self.module._fetch_scripts()
 
@@ -222,33 +279,27 @@ class CommunityScriptsSchemaHardeningTests(CommunityScriptsTestBase):
             ],
         )
         warning_messages = [message for _level, message in self.logger.messages]
-        self.assertTrue(any("Skipping malformed script" in msg for msg in warning_messages))
+        self.assertTrue(any("Skipping malformed item" in msg for msg in warning_messages))
 
-    def test_fetch_scripts_skips_malformed_scripts_list_in_category(self) -> None:
-        payload = [
-            {"scripts": "not-a-list"},
-        ]
+    def test_fetch_scripts_rejects_non_list_items(self) -> None:
+        payload = {"page": 1, "perPage": 500, "totalItems": 0, "totalPages": 1, "items": "not-a-list"}
         with self._patch_network_get(payload):
             scripts = self.module._fetch_scripts()
 
         self.assertEqual(scripts, [])
         warning_messages = [message for _level, message in self.logger.messages]
-        self.assertTrue(any("Skipping malformed scripts list" in msg for msg in warning_messages))
+        self.assertTrue(any("Unexpected items type" in msg for msg in warning_messages))
 
-    def test_fetch_scripts_handles_scripts_with_invalid_or_missing_name_slug(self) -> None:
-        payload = [
-            {
-                "scripts": [
-                    {"name": None, "slug": "missing-name"},
-                    {"name": "Missing Slug"},
-                    {"name": 123, "slug": "numeric-name"},
-                    {"name": "Numeric Slug", "slug": 456},
-                    {"name": "", "slug": "empty-name"},
-                    {"name": "Empty Slug", "slug": ""},
-                    {"name": "Valid Script", "slug": "valid-script"},
-                ]
-            }
-        ]
+    def test_fetch_scripts_handles_items_with_invalid_or_missing_name_slug(self) -> None:
+        payload = _pocketbase_response([
+            {"name": None, "slug": "missing-name"},
+            {"name": "Missing Slug"},
+            {"name": 123, "slug": "numeric-name"},
+            {"name": "Numeric Slug", "slug": 456},
+            {"name": "", "slug": "empty-name"},
+            {"name": "Empty Slug", "slug": ""},
+            {"name": "Valid Script", "slug": "valid-script"},
+        ])
         with self._patch_network_get(payload):
             scripts = self.module._fetch_scripts()
 
@@ -265,21 +316,17 @@ class CommunityScriptsSchemaHardeningTests(CommunityScriptsTestBase):
         warning_messages = [message for _level, message in self.logger.messages]
         self.assertTrue(
             any(
-                "Skipping script with invalid name/slug" in msg
+                "Skipping item with invalid name/slug" in msg
                 for msg in warning_messages
             )
         )
 
     def test_fetch_scripts_strips_whitespace_from_name_and_slug(self) -> None:
-        payload = [
-            {
-                "scripts": [
-                    {"name": "  Whitespace Name  ", "slug": "  whitespace-slug  "},
-                    {"name": "Dup", "slug": "dup"},
-                    {"name": "Dup Duplicate", "slug": "  dup  "},
-                ]
-            }
-        ]
+        payload = _pocketbase_response([
+            {"name": "  Whitespace Name  ", "slug": "  whitespace-slug  "},
+            {"name": "Dup", "slug": "dup"},
+            {"name": "Dup Duplicate", "slug": "  dup  "},
+        ])
         with self._patch_network_get(payload):
             scripts = self.module._fetch_scripts()
 
@@ -305,14 +352,10 @@ class CommunityScriptsSchemaHardeningTests(CommunityScriptsTestBase):
         )
 
     def test_init_and_search_continue_with_partial_bad_data(self) -> None:
-        payload = [
-            {
-                "scripts": [
-                    None,
-                    {"name": "Docker LXC", "slug": "docker-lxc", "description": "Docker setup"},
-                ]
-            }
-        ]
+        payload = _pocketbase_response([
+            None,
+            {"name": "Docker LXC", "slug": "docker-lxc", "description": "Docker setup"},
+        ])
         with self._patch_network_get(payload):
             self.module.setup({"name": "proxmox ve community scripts"})
             initialized = self.module.init({})
@@ -323,7 +366,7 @@ class CommunityScriptsSchemaHardeningTests(CommunityScriptsTestBase):
         self.assertEqual(len(results.items), 1)
         self.assertEqual(results.items[0]["title"], "Docker LXC")
         self.assertTrue(
-            any("Skipping malformed script" in message for _level, message in self.logger.messages)
+            any("Skipping malformed item" in message for _level, message in self.logger.messages)
         )
 
 

--- a/tools/test_data_analysis.py
+++ b/tools/test_data_analysis.py
@@ -30,6 +30,7 @@ class DataAnalysisTest(unittest.TestCase):
             params = urlencode({
                 "perPage": per_page,
                 "page": page_num,
+                "skipTotal": "false",
                 "fields": "name,slug,description",
                 "filter": "(is_deleted=false&&is_disabled=false)",
             })
@@ -70,6 +71,8 @@ class DataAnalysisTest(unittest.TestCase):
                 scripts.append({"name": name, "slug": slug, "description": description})
 
             total_pages = data.get("totalPages", 1)
+            if not isinstance(total_pages, int) or total_pages < 1:
+                self.fail(f"Unexpected totalPages value: {total_pages!r}")
             print(f"  Page {page_num}/{total_pages}: {len(items)} items")
             if page_num >= total_pages:
                 break

--- a/tools/test_data_analysis.py
+++ b/tools/test_data_analysis.py
@@ -47,7 +47,7 @@ class DataAnalysisTest(unittest.TestCase):
             if not isinstance(data, dict):
                 self.fail(f"Unexpected payload type: {type(data).__name__}")
 
-            items = data.get("items", [])
+            items = data.get("items")
             if not isinstance(items, list):
                 self.fail(f"Unexpected items type: {type(items).__name__}")
 

--- a/tools/test_data_analysis.py
+++ b/tools/test_data_analysis.py
@@ -11,56 +11,69 @@ class DataAnalysisTest(unittest.TestCase):
     @unittest.skip("This test performs live network calls and is for manual runs only.")
     def test_analyze_script_data(self):
         """
-        This test fetches real data from the Proxmox VE community scripts API
+        This test fetches real data from the PocketBase API
         to analyze its size and content.
         """
-        api_url = "https://community-scripts.github.io/ProxmoxVE/api/categories"
+        from urllib.parse import urlencode
+
+        api_base = "https://db.community-scripts.org/api/collections/script_scripts/records"
+        per_page = 500
         timeout = 30
 
-        print("\n--- Fetching real script data from the API ---")
-        try:
-            resp = httpx.get(api_url, timeout=timeout)
-            resp.raise_for_status()
-            data = resp.json()
-        except httpx.HTTPError as e:
-            self.fail(f"Failed to fetch scripts from the API: {e}")
-        except json.JSONDecodeError as e:
-            self.fail(f"Failed to decode JSON from API response: {e}")
-
-        # This logic is intentionally duplicated from _fetch_scripts to keep this
-        # analysis script self-contained and independent of the engine's internal
-        # dependencies and mocking requirements.
-        if not isinstance(data, list):
-            self.fail("Unexpected categories payload type: not a list")
+        print("\n--- Fetching real script data from PocketBase API ---")
 
         seen: set[str] = set()
         scripts: list[dict[str, t.Any]] = []
+        page_num = 0
 
-        for category in data:
-            if not isinstance(category, dict):
-                continue
-            category_scripts = category.get("scripts", [])
-            if not isinstance(category_scripts, list):
-                continue
-            for script in category_scripts:
-                if not isinstance(script, dict):
+        while True:
+            page_num += 1
+            params = urlencode({
+                "perPage": per_page,
+                "page": page_num,
+                "fields": "name,slug,description",
+                "filter": "(is_deleted=false&&is_disabled=false)",
+            })
+            url = f"{api_base}?{params}"
+
+            try:
+                resp = httpx.get(url, timeout=timeout)
+                resp.raise_for_status()
+                data = resp.json()
+            except httpx.HTTPError as e:
+                self.fail(f"Failed to fetch scripts from the API: {e}")
+            except json.JSONDecodeError as e:
+                self.fail(f"Failed to decode JSON from API response: {e}")
+
+            if not isinstance(data, dict):
+                self.fail(f"Unexpected payload type: {type(data).__name__}")
+
+            items = data.get("items", [])
+            if not isinstance(items, list):
+                self.fail(f"Unexpected items type: {type(items).__name__}")
+
+            for item in items:
+                if not isinstance(item, dict):
                     continue
-                name = script.get("name")
-                slug = script.get("slug")
+                name = item.get("name")
+                slug = item.get("slug")
                 if not isinstance(name, str) or not isinstance(slug, str):
                     continue
                 name = name.strip()
                 slug = slug.strip()
                 if not name or not slug:
                     continue
-                if script.get("disable") is True:
-                    continue
                 if slug in seen:
                     continue
-                description = script.get("description")
+                description = item.get("description")
                 description = description[:500] if isinstance(description, str) else ""
                 seen.add(slug)
                 scripts.append({"name": name, "slug": slug, "description": description})
+
+            total_pages = data.get("totalPages", 1)
+            print(f"  Page {page_num}/{total_pages}: {len(items)} items")
+            if page_num >= total_pages:
+                break
 
         print(f"Fetched {len(scripts)} valid scripts.")
 


### PR DESCRIPTION
## **User description**
## Summary

- Rewrites `_fetch_scripts()` to paginate through the PocketBase API at `db.community-scripts.org` instead of the removed `/api/categories` GitHub Pages endpoint
- Server-side filtering via `is_deleted=false&&is_disabled=false` replaces client-side disable checks
- Updates test suite (10 existing tests adapted + 3 new pagination/empty tests, all 13 passing)
- Updates `tools/test_data_analysis.py` and `README.md` to reflect new API and site URL

Closes #23
Related: community-scripts/ProxmoxVE#13545

## Test plan

- [x] All 13 unit tests pass
- [x] Live API smoke test: `db.community-scripts.org` returns 552 active scripts
- [x] Script URL verified: `community-scripts.org/scripts/docker` returns 200
- [ ] Manual end-to-end test on a SearXNG instance

🤖 Generated with [Claude Code](https://claude.ai/claude-code)


___

## **CodeAnt-AI Description**
**Retarget Proxmox VE community script search to the new community-scripts.org API**

### What Changed
- Search now pulls scripts from the new PocketBase API on community-scripts.org instead of the retired GitHub Pages endpoint
- The engine now returns the newer catalogue size and script links for the current site
- Searches continue to skip broken entries and keep duplicate slugs from colliding
- Documentation and test data were updated to match the new site and API format

### Impact
`✅ Working Proxmox script search after the site migration`
`✅ Access to the current script catalogue`
`✅ Fewer broken search results from outdated links`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proxmox VE Community Scripts catalogue now lists ~550 install scripts and search now uses the official paginated community-scripts API.

* **Documentation**
  * README updated with the new catalogue link and revised script count.

* **Tests**
  * Test suite adapted for paginated API envelopes, multi-page aggregation and related error handling.

* **Tools**
  * Data analysis tooling updated to fetch and process paginated script records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->